### PR TITLE
Bug: Parsing http-port fails on config

### DIFF
--- a/src/canopy/config/canopy_config.go
+++ b/src/canopy/config/canopy_config.go
@@ -446,7 +446,7 @@ func (config *CanopyConfig) LoadConfigJson(jsonObj map[string]interface{}) error
             config.hostname, ok = v.(string)
         case "http-port": 
             var port float64
-            port, ok := v.(float64)
+            port, ok = v.(float64)
             if ok {
                 config.httpPort = int16(port)
             }


### PR DESCRIPTION
Hi Gregg, 
I fixed a tiny issue parsing the http-port config option from JSON. It was throwing a: 
`ERROR 2015/09/17 15:25:27 canopy-server.go:64: Configuration error: %s Incorrect JSON type for http-port`
due to a type mismatch on the port. 
Loving canopy so far. Great work!
